### PR TITLE
allow params to be passed to Stocks.chart

### DIFF
--- a/__test__/Stocks.test.ts
+++ b/__test__/Stocks.test.ts
@@ -94,6 +94,13 @@ test("Batch Symbols Ceo Compensation", () => {
     .then(res => expect(res).toHaveProperty("GOOGL"));
 });
 
+test("Batch Symbols Chart with params", () => {
+  return iex
+    .batchSymbols("aapl,amzn,fb")
+    .chart("5d", { chartCloseOnly: true })
+    .then(res => expect(res).toHaveProperty("AAPL"));
+});
+
 test("Crypto currencies quote", () => {
   return iex
     .crypto("btcusd")

--- a/src/stocks.ts
+++ b/src/stocks.ts
@@ -33,7 +33,25 @@ class Stocks {
    * Returns adjusted and unadjusted historical data for up to 15 years.
    * `Data Weight: 1,000 per symbol per period`
    */
-  public chart = (): Promise<any> => this.req.request(`chart`);
+  public chart = (
+    range?: iex.Range,
+    params?: iex.ChartParams
+  ): Promise<any> => {
+    const paramValues = [];
+    if (range) {
+      paramValues.push(["range", range]);
+    }
+    if (params) {
+      paramValues.push(...Object.entries(params));
+    }
+    return this.req.request(
+      `chart${
+        paramValues.length > 0
+          ? "&" + paramValues.map((v: string[]) => `${v[0]}=${v[1]}`).join("&")
+          : ""
+      }`
+    );
+  };
 
   /**
    * returns cash flow data. Available quarterly or annually, with the default being the last available quarter.


### PR DESCRIPTION
Per IEX docs it's possible to pass params into the request for batch symbol charts: https://iexcloud.io/docs/api/#batch-requests

This PR adds that functionality to this client.

Thanks for your work on this!